### PR TITLE
Tab 8 fix go to site buttons in phone comparison

### DIFF
--- a/backend/models/financialProducts.model.js
+++ b/backend/models/financialProducts.model.js
@@ -1,10 +1,11 @@
 class PhoneModel {
-    constructor(company, title, information, data, cost, CTA) {
+    constructor(company, title, information, data, cost, link, CTA) {
         this.company = company;
         this.title = title;
         this.information = information;
         this.data = data;
         this.cost = cost;
+        this.link = link;
         this.CTA = CTA;
     }
 }

--- a/frontend/src/components/ui/SortedTable.tsx
+++ b/frontend/src/components/ui/SortedTable.tsx
@@ -81,9 +81,9 @@ const SortedTable: React.FC<SortedTableProps> = ({
             href={data?.link}
             target="_blank"
             colorScheme="whatsapp"
-            variant="outline"
+            variant={data?.link != null ? "outline" : "hidden"}
           >
-            Go to site
+            {data?.link != null ? "Go to site" : ""}
           </Button>
         </Td>
       </Tr>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -18,6 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground cursor-pointer",
         link: "text-primary underline-offset-4 hover:underline",
+        hidden: ""
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
Fixed links for Go to Site buttons.

![image](https://github.com/ethanrong7/recruitApp/assets/95570212/04b23961-3cc7-46e2-a3f9-abca99f040fb)

Hid buttons of any products without links.

![image](https://github.com/ethanrong7/recruitApp/assets/95570212/6d431c9a-28f8-48dd-8a19-1a9811d164b4)
