### PR TITLE
Added Internet UI components

### DIFF
--- a/frontend/src/components/comparison/ProductComparison.tsx
+++ b/frontend/src/components/comparison/ProductComparison.tsx
@@ -46,6 +46,7 @@ const ProductComparison: React.FC<ProductComparisonProps> = ({
       [Constants.TABLE_TYPE.MORTGAGE]: state.global.comparison.mortgage,
       [Constants.TABLE_TYPE.PHONE]: state.global.comparison.phone,
       [Constants.TABLE_TYPE.GAS]: state.global.comparison.gas,
+      [Constants.TABLE_TYPE.INTERNET]: state.global.comparison.internet
     };
 
     return comparisonMap[ProductType];
@@ -89,6 +90,7 @@ const ProductComparison: React.FC<ProductComparisonProps> = ({
       [Constants.TABLE_TYPE.PHONE]: Constants.PHONE_TABLE_HEADERS,
       [Constants.TABLE_TYPE.ELECTRICITY]: Constants.ELECTRICITY_TABLE_HEADERS,
       [Constants.TABLE_TYPE.GAS]: Constants.GAS_TABLE_HEADERS,
+      [Constants.TABLE_TYPE.INTERNET]: Constants.INTERNET_TABLE_HEADERS,
     };
     if (tableHeadersMap.hasOwnProperty(ProductType)) {
       setTableHeader(tableHeadersMap[ProductType]);

--- a/frontend/src/components/comparison/SearchBox/InternetSearchBox.tsx
+++ b/frontend/src/components/comparison/SearchBox/InternetSearchBox.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from "react";
+import { Text, Select, Button } from "@chakra-ui/react";
+import { useSelector, useDispatch } from "react-redux";
+import { RootState } from "@/store";
+import Constants from "@/constants";
+
+const InternetSearchBox: React.FC = () => {
+    return (
+        <>
+        <Text textAlign="left" p={1}>
+            Internet Type
+        </Text>
+        <Select
+        name="internetType">
+            <option>NBN</option>
+            <option>Wireless Broadband</option>
+        </Select>
+        <Text textAlign="left" p={1}>
+            Internet Speed
+        </Text>
+        <Select
+        name="speedTier">
+            <option>Basic plans (or higher)</option>
+            <option>Standard plans (or higher)</option>
+            <option>Fast plans (or higher)</option>
+            <option>Superfast plans (or higher)</option>
+            <option>Ultrafast plans (or higher)</option>
+        </Select>
+        <Button
+        colorScheme="blue"
+        p={2}
+        mt="3"
+        >
+            Search
+        </Button>
+        </>
+    )
+}
+
+export default InternetSearchBox

--- a/frontend/src/components/comparison/SearchBox/SearchBox.tsx
+++ b/frontend/src/components/comparison/SearchBox/SearchBox.tsx
@@ -4,6 +4,7 @@ import Constants from "@/constants";
 import MortgageSearchBox from "./MortgageSearchBox";
 import UtilitySearchBox from "./UtilitySearchBox";
 import PhoneSearchBox from "./PhoneSearchBox";
+import InternetSearchBox from "./InternetSearchBox";
 
 /**
  * Component: SearchBox.tsx
@@ -39,6 +40,9 @@ const SearchBox: React.FC<SearchBoxProps> = ({ ProductType }) => {
     if (ProductType === Constants.TABLE_TYPE.PHONE) {
       return <PhoneSearchBox />;
     } 
+    if (ProductType === Constants.TABLE_TYPE.INTERNET) {
+      return <InternetSearchBox />;
+    }
   };
 
   return (

--- a/frontend/src/components/ui/SortedTable.tsx
+++ b/frontend/src/components/ui/SortedTable.tsx
@@ -24,6 +24,14 @@ import {
 import { useNavigate, useLocation } from "react-router-dom";
 import Constants from "@/constants";
 
+interface InternetData {
+  company: string;
+  information: string;
+  stats: string;
+  monthlyCost: string;
+  CTA: string;
+}
+
 interface PhoneData {
   company: string;
   data: any[];
@@ -90,6 +98,28 @@ const SortedTable: React.FC<SortedTableProps> = ({
       });
       navigate(`${location.pathname}?${params.toString()}`);
     }
+  };
+
+  const InternetData = () => {
+    return tableData.map((data: InternetData, index: number) => (
+      <Tr key={index}>
+        <Td>
+          Company Logo
+        </Td>
+        <Td>Title</Td>
+        <Td>Data / Speed Stats</Td>
+        <Td>Cost</Td>
+        <Td>
+          <Button
+            as="a"
+            colorScheme="whatsapp"
+            variant={data?.company != null ? "outline" : "hidden"}
+            >
+              "Go to site"
+            </Button>
+        </Td>
+      </Tr>
+    ));
   };
 
   const PhoneData = () => {
@@ -232,6 +262,7 @@ const SortedTable: React.FC<SortedTableProps> = ({
               {tableType === Constants.TABLE_TYPE.MORTGAGE && MortgageData()}
               {tableType === Constants.TABLE_TYPE.ELECTRICITY && ElectricityData()}
               {tableType === Constants.TABLE_TYPE.GAS && GasData()}
+              {tableType === Constants.TABLE_TYPE.INTERNET && InternetData()}
             </Tbody>
           )}
         </Table>

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -12,6 +12,13 @@ const Constants = {
         ELECTRICITY: "Electricity",
         GAS: "Gas"
     },
+    INTERNET_TABLE_HEADERS: [
+        "company",
+        "information",
+        "speed",
+        "cost",
+        "CTA"
+    ],
     PHONE_TABLE_HEADERS: [
         "company",
         "information",

--- a/frontend/src/layouts/Comparison.tsx
+++ b/frontend/src/layouts/Comparison.tsx
@@ -115,7 +115,10 @@ const Comparison: React.FC = () => {
           <Route
             path="/internet"
             element={
-              <p>Internet WIP</p>
+              <ProductComparison
+              key={`${Constants.TABLE_TYPE.INTERNET}`}
+              ProductType={Constants.TABLE_TYPE.INTERNET}
+              />
             }
           />
         </Routes>

--- a/frontend/src/reduxFeatures/comparisonSlice.tsx
+++ b/frontend/src/reduxFeatures/comparisonSlice.tsx
@@ -5,6 +5,7 @@ interface ComparisonState {
   phone: PhoneParams;
   mortgage: MortgageParams;
   gas: GasParams;
+  internet: InternetParams;
   search: {
     isSearching: boolean;
   };
@@ -23,6 +24,11 @@ export interface MortgageParams {
 
 export interface GasParams {
   postcode?: string | null;
+}
+
+export interface InternetParams {
+  internetType: string | null;
+  speedTier: string | null;
 }
 
 export interface PhoneParams {
@@ -46,6 +52,10 @@ const initialState: ComparisonState = {
   },
   gas: {
     postcode: null,
+  },
+  internet: {
+    internetType: "NBN",
+    speedTier: "Standard",
   },
   search: {
     isSearching: false,


### PR DESCRIPTION
ProductComparison returns a `<Box>` container with 3 child components `<ProductOverview>`, `<SearchBox>`, and `<SortedTable>` for Overview, Filter Result, Available Plans respectively.

### Adding Overview
Already implemented, just had to add Internet expense to finances/visualise and save. The monthly value is then available to ProductOverview.tsx which is called by ProductComparison.tsx

### Adding Filter Result
- SearchBox.tsx compares the ProductType string against the TABLE_TYPEs in constants.tsx, would have to add Internet to TABLE_TYPE in constant.tsx but already exists. 
- Created InternetSearchBox.tsx
- Created and exported React Functional Component `InternetSearchBox` which returns a `<Text>` element. 
- Imported InternetSearchBox into SearchBox.tsx
- Added if statement to SearchBox react component to match with TABLE_TYPE Internet and return new `<InternetSearchBox />` child component.

### Adding Available Plans
- SortedTable.tsx only imports from Pagination and Constants. 
- Added INTERNET_TABLE_HEADERS string array to constants.tsx with 5 placeholder strings. 
- Created InternetData interface class in SortedTable.tsx, alternatively could have left this and created an entirely placeholder table using `<TableContainer>`, but would need to be changed later. 
- Created InternetData function in SortedTable.tsx that returns empty chakra ui table with placeholder elements that should appear once data exists. 
- Added `{tableType === Constants.TABLE_TYPE.INTERNET && InternetData()}` to the table body element returned by the SortedTable component. 
- At this point I couldn't figure out why my table headers wouldn't load 
- Found that I had to add the INTERNET_TABLE_HEADERS constant to the useEffect in ProductComparison.tsx that creates a tableHeadersMap

![image](https://github.com/ethanrong7/recruitApp/assets/95570212/fbac6865-2ec3-4df6-ac4c-17d6d9550e21)
